### PR TITLE
switch out jiffy for jsx

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,5 +8,5 @@
 
 {deps, [
     {nkpacket, ".*", {git, "git://github.com/nekso/nkpacket.git", {tag, "v0.3.0"}}},
-    {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", {tag, "0.13.3"}}}
+    {jsx, ".*", {git, "https://github.com/talentdeficit/jsx.git", {tag, "v2.6.0"}}}
 ]}.

--- a/src/nkdocker_opts.erl
+++ b/src/nkdocker_opts.erl
@@ -53,7 +53,7 @@ iter_path([], Acc) ->
     Acc;
 
 iter_path([{Key, Val}|Rest], Acc) when is_map(Val) ->
-    iter_path([{Key, jiffy:encode(Val)}|Rest], Acc);
+    iter_path([{Key, jsx:encode(Val)}|Rest], Acc);
 
 iter_path([{Key, Val}|Rest], Acc) ->
     iter_path(Rest, list_to_binary([Acc, $&, to_binary(Key), $=, to_urlencode(Val)])).
@@ -636,5 +636,3 @@ parse_text() ->
             'VolumesFrom' := [<<"from2:ro">>, <<"from1">>]
         }
     } = Op.
-    
-    

--- a/src/nkdocker_server.erl
+++ b/src/nkdocker_server.erl
@@ -357,7 +357,7 @@ get_version(#state{conn=Conn, conn_opts=ConnOpts}) ->
                     {nkdocker, {head, From, 200, _, false}} ->
                         receive
                             {nkdocker, {data, From, Data, true}} ->
-                                catch jiffy:decode(Data, [return_maps])
+                                catch jsx:decode(Data, [return_maps])
                         after
                             5000 -> timeout
                         end
@@ -569,7 +569,7 @@ parse_body(#cmd{headers=Headers, mode=Mode, body=Body, chunked=Chunked}) ->
                 _ -> 
                     Body
             end,
-            case catch jiffy:decode(Body1, [return_maps]) of
+            case catch jsx:decode(Body1, [return_maps]) of
                 {'EXIT', _} ->
                     {error, {invalid_json, Body}};
                 Obj ->
@@ -628,5 +628,3 @@ do_stop(Cmd, Msg, #state{cmds=Cmds}=State) ->
     end,
     Cmds1 = lists:keydelete(From, #cmd.from, Cmds),
     State#state{cmds=Cmds1}.
-
-


### PR DESCRIPTION
I was disappointed to see jiffy was used after I had read "100% Erlang" in the readme :). I'm not sure if you are open to this patch but I thought I'd try.

I'm also working on `rebar3` support if you are interested. The blocker right now is getting the tests to run. `rebar3` doesn't work by default with eunit tests in `test/` like this. So I may just switch it to Common Test and see if you like that or not :). Or I'll be poking @talentdeficit to help me figur eout the eunit with rebar3.
